### PR TITLE
add DwollaBase plugin with core settings

### DIFF
--- a/src/main/scala/com/dwolla/sbt/dwollabase/DwollaBase.scala
+++ b/src/main/scala/com/dwolla/sbt/dwollabase/DwollaBase.scala
@@ -1,0 +1,71 @@
+package com.dwolla.sbt.dwollabase
+
+import sbt._, sbt.Keys._
+
+object DwollaBase extends AutoPlugin {
+
+  override def trigger  = allRequirements
+
+  override def buildSettings = Seq(
+    addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.6"),
+    addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full),
+    addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.2.1"),
+    resolvers ++= Seq(
+      Resolver.bintrayRepo("Dwolla", "maven"),
+      Resolver.sonatypeRepo("releases"),
+    ),
+    scalacOptions ++= Seq(
+      "-deprecation",                      // Emit warning and location for usages of deprecated APIs.
+      "-encoding", "utf-8",                // Specify character encoding used by source files.
+      "-explaintypes",                     // Explain type errors in more detail.
+      "-feature",                          // Emit warning and location for usages of features that should be imported explicitly.
+      "-language:existentials",            // Existential types (besides wildcard types) can be written and inferred
+      "-language:experimental.macros",     // Allow macro definition (besides implementation and application)
+      "-language:higherKinds",             // Allow higher-kinded types
+      "-language:implicitConversions",     // Allow definition of implicit functions called views
+      "-unchecked",                        // Enable additional warnings where generated code depends on assumptions.
+      "-Xcheckinit",                       // Wrap field accessors to throw an exception on uninitialized access.
+      "-Xfatal-warnings",                  // Fail the compilation if there are any warnings.
+      "-Xfuture",                          // Turn on future language features.
+      "-Xlint:adapted-args",               // Warn if an argument list is modified to match the receiver.
+      "-Xlint:by-name-right-associative",  // By-name parameter of right associative operator.
+      "-Xlint:delayedinit-select",         // Selecting member of DelayedInit.
+      "-Xlint:doc-detached",               // A Scaladoc comment appears to be detached from its element.
+      "-Xlint:inaccessible",               // Warn about inaccessible types in method signatures.
+      "-Xlint:infer-any",                  // Warn when a type argument is inferred to be `Any`.
+      "-Xlint:missing-interpolator",       // A string literal appears to be missing an interpolator id.
+      "-Xlint:nullary-override",           // Warn when non-nullary `def f()' overrides nullary `def f'.
+      "-Xlint:nullary-unit",               // Warn when nullary methods return Unit.
+      "-Xlint:option-implicit",            // Option.apply used implicit view.
+      "-Xlint:package-object-classes",     // Class or object defined in package object.
+      "-Xlint:poly-implicit-overload",     // Parameterized overloaded implicit methods are not visible as view bounds.
+      "-Xlint:private-shadow",             // A private field (or class parameter) shadows a superclass field.
+      "-Xlint:stars-align",                // Pattern sequence wildcard must align with sequence component.
+      "-Xlint:type-parameter-shadow",      // A local type parameter shadows a type already in scope.
+      "-Xlint:unsound-match",              // Pattern match may not be typesafe.
+      "-Yno-adapted-args",                 // Do not adapt an argument list (either by inserting () or creating a tuple) to match the receiver.
+      "-Ypartial-unification",             // Enable partial unification in type constructor inference
+      "-Ywarn-dead-code",                  // Warn when dead code is identified.
+      "-Ywarn-inaccessible",               // Warn about inaccessible types in method signatures.
+      "-Ywarn-infer-any",                  // Warn when a type argument is inferred to be `Any`.
+      "-Ywarn-nullary-override",           // Warn when non-nullary `def f()' overrides nullary `def f'.
+      "-Ywarn-nullary-unit",               // Warn when nullary methods return Unit.
+      "-Ywarn-numeric-widen",              // Warn when numerics are widened.
+      "-Ywarn-value-discard",              // Warn when non-Unit expression results are unused.
+    ) ++ (scalaBinaryVersion.value match {
+      case "2.12" ⇒ Seq(
+        "-Ywarn-extra-implicit",             // Warn when more than one implicit parameter section is defined.
+        "-Xlint:constant",                   // Evaluation of a constant arithmetic expression results in an error.
+        "-Ywarn-unused:explicits",           // Warn if an explicit parameter is unused.
+        "-Ywarn-unused:implicits",           // Warn if an implicit parameter is unused.
+        "-Ywarn-unused:imports",             // Warn if an import selector is not referenced.
+        "-Ywarn-unused:locals",              // Warn if a local definition is unused.
+        "-Ywarn-unused:patvars",             // Warn if a variable bound in a pattern is unused.
+        "-Ywarn-unused:privates",            // Warn if a private member is unused.
+      )
+      case _ ⇒ Seq.empty
+    }),
+    scalacOptions in (Compile, console) --= Seq("-Ywarn-unused:imports", "-Xfatal-warnings"),
+    scalacOptions in Compile in Test -= "-Xfatal-warnings",
+  )
+}


### PR DESCRIPTION
I've been copying and pasting these settings into a whole bunch of different Scala projects, so I thought it would be useful to have an sbt plugin that defines them that we can pull in instead.

(Eventually, this plugin will be referenced by our internal `dwolla-docker-app` plugin, because this one is more general. It applies to things that won't be deployed in Docker containers, like AWS Lambda functions, and could also be useful outside Dwolla.)