### PR TITLE
 toggling compiler settings should apply to subprojects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 jdk: oraclejdk8
 scala:
-  - 2.12.7
+  - 2.12.8
 
 cache:
   directories:
@@ -16,7 +16,7 @@ env:
   global:
     secure: "rxxzxM5tEPSf2hhKjT7b1nMP+Ge2GDghwGCzR1T6dUhOctrR84PGheqQpNzHhVlMHPtnRYNIof7SWieX2xr6FpykeIXV13IjIHyaZ0c0mea0Zf1Iljbu+TZyT/ptRZhpqQPTmHbMNi/1TPC4BPCZRslUS4MeT7wm80vmJURJE/dWr8Ccqbb4t3dnT5wq381omnJD0WOiztUaoXJOvaidln1Tfnoj1lCLo0ENzwZDpKRGWxlE7aQoCEkLgIkvt5aG8aqFrbjD7Axmx3nZXXRoWHnHc2fLlqHek4OhAvm42kOOgzCZzAMQy3E6YedCdOdX9vUgKeKaVF3KCIbrWaSHaLcRJReRFL6/Ystu/0h5gs8FcFs3fGT0G+KM07ctTnRCo2+863Y23nfxwp4jacmrqWzl/XeMORCIankhgDqwC9YVTP9jd3u+HeabDHC/dqChvRk/FpKx1Gj9yJxE7guzlxMrON3Ra9Qv90WplbYCu1y1cx7RPHHqO7u/sINJ3LwHaq0aonhx3X6626F1MbM/24ouTIhGY23BVfZN6IXQgvV/6Hmtb96DBCEgJKj4Cl+pld91INal1u8mXLKRdy9uHFbgRmxS5/MSZJ7RBFUebNO3gC1BnGq5NXtBTLj+bh8tM4R/VwhoZPCmtkA27bLm1KTw8POA4ZIPl/i/x0Duf3k="
   matrix:
-    - SBT_VERSION="1.2.6"
+    - SBT_VERSION="1.2.8"
 
 script:
   - sbt "^^${SBT_VERSION}" test scripted
@@ -30,4 +30,4 @@ deploy:
     script: .travis/release.sh
     on:
       branch: master
-      condition: $SBT_VERSION == "1.2.6" && $(git log -n1 --format=format:"%an") != "Dwolla Bot"
+      condition: $SBT_VERSION == "1.2.8" && $(git log -n1 --format=format:"%an") != "Dwolla Bot"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.6
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.9")
-addSbtPlugin("com.dwijnand" % "sbt-travisci" % "1.1.3")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")
+addSbtPlugin("com.dwijnand" % "sbt-travisci" % "1.2.0")

--- a/src/main/scala/com/dwolla/sbt/dwollabase/DwollaBase.scala
+++ b/src/main/scala/com/dwolla/sbt/dwollabase/DwollaBase.scala
@@ -73,8 +73,8 @@ object DwollaBase extends AutoPlugin {
     scalacOptions in Compile in Test -= "-Xfatal-warnings",
     scalacOptions --= sys.props.get("idea.runid").map(_ => "-Xfatal-warnings"),
     commands ++= Seq(
-      ToggleScalacOption("toggleFatalWarnings", "-Xfatal-warnings", "Fatal warnings"),
-      ToggleScalacOption("toggleImplicitLogging", "-Xlog-implicits", "Implicit logging"),
+      ToggleScalacOption("toggleFatalWarnings", "-Xfatal-warnings"),
+      ToggleScalacOption("toggleImplicitLogging", "-Xlog-implicits"),
     ),
   )
 }

--- a/src/main/scala/com/dwolla/sbt/dwollabase/DwollaBase.scala
+++ b/src/main/scala/com/dwolla/sbt/dwollabase/DwollaBase.scala
@@ -7,7 +7,7 @@ object DwollaBase extends AutoPlugin {
   override def trigger  = allRequirements
 
   override def buildSettings = Seq(
-    scalaVersion := "2.12.7",
+    scalaVersion := "2.12.8",
   )
 
   override def projectSettings = Seq(

--- a/src/sbt-test/dwolla-base/cross-build/.travis.yml
+++ b/src/sbt-test/dwolla-base/cross-build/.travis.yml
@@ -2,6 +2,6 @@ language: scala
 
 scala:
   - 2.11.12
-  - 2.12.7
+  - 2.12.8
 
 jdk: oraclejdk8

--- a/src/sbt-test/dwolla-base/cross-build/project/plugins.sbt
+++ b/src/sbt-test/dwolla-base/cross-build/project/plugins.sbt
@@ -9,4 +9,4 @@
 libraryDependencies ++= Seq(
   "ch.qos.logback" % "logback-classic" % "1.2.3"
 )
-addSbtPlugin("com.dwijnand" % "sbt-travisci" % "1.1.3")
+addSbtPlugin("com.dwijnand" % "sbt-travisci" % "1.2.0")

--- a/src/sbt-test/dwolla-base/cross-build/test
+++ b/src/sbt-test/dwolla-base/cross-build/test
@@ -1,7 +1,7 @@
 > clean
 
 # Check that different Scala binary versions have different options set
-> ++2.12.7 check212
+> ++2.12.8 check212
 > ++2.11.12 check211
 
 # Run +crossBuild to make sure the TravisCI plugin injected both Scala versions

--- a/src/sbt-test/dwolla-base/toggle-fatal-warnings/build.sbt
+++ b/src/sbt-test/dwolla-base/toggle-fatal-warnings/build.sbt
@@ -1,14 +1,20 @@
 name := "Toggling -Xfatal-warnings on and off"
 
-val app = project in file(".")
+val subproject = project in file("subproject")
+
+val app = (project in file("."))
+    .aggregate(subproject)
 
 TaskKey[Unit]("fatalWarningsIsOn") := {
   val scalacOptionsValue = scalacOptions.value
+  val subprojectScalacOptionsValue = (scalacOptions in subproject).value
 
-  val scalacOptionsError = if (scalacOptionsValue.contains("-Xfatal-warnings")) None
-  else Option(s"""scalacOptions does not contain "-Xfatal-warnings".""")
+  val scalacOptionsError = Seq(scalacOptionsValue → "root", subprojectScalacOptionsValue → "subproject").map { case (v, k) ⇒
+    if (v.contains("-Xfatal-warnings")) None
+    else Option(s"""$k scalacOptions does not contain "-Xfatal-warnings", but it should.""")
+  }
 
-  val allErrors: Seq[String] = Seq(scalacOptionsError)
+  val allErrors: Seq[String] = scalacOptionsError
     .collect {
       case Some(msg) ⇒ s"Error: $msg"
     }
@@ -22,11 +28,14 @@ TaskKey[Unit]("fatalWarningsIsOn") := {
 
 TaskKey[Unit]("fatalWarningsIsOff") := {
   val scalacOptionsValue = scalacOptions.value
+  val subprojectScalacOptionsValue = (scalacOptions in subproject).value
 
-  val scalacOptionsError = if (!scalacOptionsValue.contains("-Xfatal-warnings")) None
-  else Option(s"""scalacOptions contains "-Xfatal-warnings".""")
+  val scalacOptionsError = Seq(scalacOptionsValue → "root", subprojectScalacOptionsValue → "subproject").map { case (v, k) ⇒
+    if (!v.contains("-Xfatal-warnings")) None
+    else Option(s"""$k scalacOptions contains "-Xfatal-warnings", but it should not.""")
+  }
 
-  val allErrors: Seq[String] = Seq(scalacOptionsError)
+  val allErrors: Seq[String] = scalacOptionsError
     .collect {
       case Some(msg) ⇒ s"Error: $msg"
     }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.4.0-SNAPSHOT"
+version in ThisBuild := "1.3.1-SNAPSHOT"


### PR DESCRIPTION
Previously the commands implemented using `ToggleScalacOption` only changed the settings for the root project. The improved implementation should apply the changes anywhere the underlying setting is defined.